### PR TITLE
Added inheritance support to the configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ downloadDB.bat
 # ----
 .DS_Store
 
+# Log files
+*.log
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ npm install
 
    #### Structure of `obfuscationCfg.yaml`
    The configuration file is divided into three main sections: `general`, `columns` and `tables`.
+   Also, there is an inheritance order on the configuration sections:
+   - `tables` inherits `columns`
+   - `columns` inherits `general`
+   
+   This means you can set very broad settings in general, and then override them for specific columns and, if needed, override it for each table.
+
 
    #### 1. General Rules
    - `type`: Specifies the data type for which the rule applies (e.g., `string`).
@@ -124,7 +130,6 @@ npm install
    
      - This configuration file allows for fine-grained control over how different data types, columns and tables are handled.
      - Note that each rule must have its implementation in the [ObfuscatorStrategyMap](src%2Fclasses%2Fobfuscators%2FObfuscatorStrategyMap.js), The function name must be matching the rule name.
-
 
 3. **Running the Tool**:
    ```

--- a/src/classes/DumpLoader.js
+++ b/src/classes/DumpLoader.js
@@ -6,6 +6,7 @@ import { createReadStream, createWriteStream } from 'fs';
 import os from 'os';
 import path from 'path';
 import readline from 'readline';
+import fs from 'fs';
 
 const execAsync = util.promisify(exec);
 
@@ -106,6 +107,9 @@ export default class DumpLoader {
   }
 
   async load(dumpFilePath) {
+    if (!fs.existsSync(dumpFilePath)) {
+      throw new Error(`Dump file not found: ${dumpFilePath}`);
+    }
     const command = `mysql -h ${this.host} -u ${this.user} -p${this.password} --port=${this.port} ${this.database} < ${dumpFilePath}`;
     await execAsync(command);
   }

--- a/src/classes/Obfuscator.js
+++ b/src/classes/Obfuscator.js
@@ -65,11 +65,16 @@ export default class Obfuscator {
     for (const record of records) {
       for (const [columnName, columnDetails] of Object.entries(columns)) {
 
-        const columnRule = tableRule?.columns?.find(col => col.name === columnName);
+        const columnRule = this.rules?.columns?.find(col => col.name === columnName);
+        const tableColumnRule = tableRule?.columns?.find(col => col.name === columnName);
         const columnTypeCategory = this.getTypeCategory(columnDetails.type);
-        const generalRule = this.rules.general.find(rule => rule.type === columnTypeCategory);
+        const generalRule = this.rules.general?.find(rule => rule.type === columnTypeCategory);
 
-        const ruleToApply = columnRule || generalRule;
+        // Loads the rules in a way that the table-specific inherits from the column-specific and all inherit from the general one
+        const ruleToApply = (generalRule || columnRule || tableColumnRule) ? {
+          ...(generalRule || {}), ...(columnRule || {}), ...(tableColumnRule || {})
+        } : undefined
+
         let {obfuscationRule, ignorePattern, ignore = false} = ruleToApply || {};
         // Remove inner whitespace from ignore pattern
         ignorePattern = ignorePattern?.replace(/\s/g, '');


### PR DESCRIPTION
Changed the obfuscator so that the configuration has an inheritance order: `tables` inherits from `columns`, which inherits from `general`.

Configuration defined in the derived config section may override the configuration defined in the base one.