### PR TITLE
[QI-14627] Fix Doc Builder corruption in HTML obfuscation

### DIFF
--- a/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
@@ -347,9 +347,10 @@ describe("data-record-sub-model-data", () => {
     const shared = new DictionaryObfuscatorStrategy();
     const strategy = new HTMLObfuscatorStrategy(shared);
     const link = {
-      uuid: "cf40e9ac",
+      uuid: "cf40e9ac-1d22-4a7f-9f4e-77b0c1a9e551",
       linkType: "Attachment",
       fileName: "Report v1.pdf",
+      S3TmpKey: "clientSchemaName/91b85d5c/Report v1.pdf",
     };
     const nestedLinks = JSON.stringify([
       { uuid: "bcef9bfa", linkType: "Link" },
@@ -389,9 +390,16 @@ describe("data-record-sub-model-data", () => {
     // Free text is replaced but keeps its line break, so the escapes stay valid JSON.
     expect(parsed.targetJustification).not.toContain("Not Less Than");
     expect(parsed.targetJustification).toContain("\n");
-    // Link data mirrors database JSON columns that the column rules skip, so it stays as is.
+    // A JSON string value still mirrors a database JSON column that the column rules skip.
     expect(parsed.acceptanceCriteriaLinks).toBe(nestedLinks);
-    expect(parsed.link).toEqual(link);
+    // Link data is customer data. The shape survives so the app can still read it, but the file
+    // name and the customer schema name are gone.
+    expect(parsed.link.uuid).toBe(link.uuid);
+    expect(parsed.link.linkType).toBe("Attachment");
+    expect(parsed.link.fileName).toBe("attachment.pdf");
+    expect(parsed.link.S3TmpKey).toBe("obfuscated/91b85d5c/attachment.pdf");
+    expect(JSON.stringify(parsed)).not.toContain("Report v1.pdf");
+    expect(JSON.stringify(parsed)).not.toContain("clientSchemaName");
   });
 
   test("filters targetValue matches the column obfuscation through the shared dictionary", () => {

--- a/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
@@ -1,4 +1,6 @@
 import { HTMLObfuscatorStrategy } from "../../src/classes/obfuscators/HTMLObfuscatorStrategy.js";
+import { DictionaryObfuscatorStrategy } from "../../src/classes/obfuscators/DictionaryObfuscatorStrategy.js";
+import ObfuscatorStrategyMap from "../../src/classes/obfuscators/ObfuscatorStrategyMap.js";
 import { parse } from "node-html-parser";
 
 describe("HTMLObfuscatorStrategy", () => {
@@ -9,38 +11,41 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("obfuscates text content while preserving HTML structure", () => {
-    const input = '<p>Hello World</p><div>Test content</div>';
+    const input = "<p>Hello World</p><div>Test content</div>";
     const result = strategy.obfuscateString(input);
 
     expect(result).toMatch(/<p>.*<\/p><div>.*<\/div>/);
-    expect(result).not.toContain('Hello World');
-    expect(result).not.toContain('Test content');
+    expect(result).not.toContain("Hello World");
+    expect(result).not.toContain("Test content");
   });
 
   test("preserves text in elements with qbd-output class", () => {
-    const input = '<p>This should be obfuscated</p><span class="qbd-output">This should be preserved</span>';
+    const input =
+      '<p>This should be obfuscated</p><span class="qbd-output">This should be preserved</span>';
     const result = strategy.obfuscateString(input);
 
-    expect(result).toContain('This should be preserved');
-    expect(result).not.toContain('This should be obfuscated');
+    expect(result).toContain("This should be preserved");
+    expect(result).not.toContain("This should be obfuscated");
   });
 
   test("not preserves text in elements with qbd-output-direct-scope-widget class", () => {
-    const input = '<p>This should be obfuscated</p><span class="qbd-output qbd-output-direct-scope-widget">This should not be preserved</span>';
+    const input =
+      '<p>This should be obfuscated</p><span class="qbd-output qbd-output-direct-scope-widget">This should not be preserved</span>';
     const result = strategy.obfuscateString(input);
 
-    expect(result).not.toContain('This should not be preserved');
-    expect(result).not.toContain('This should be obfuscated');
+    expect(result).not.toContain("This should not be preserved");
+    expect(result).not.toContain("This should be obfuscated");
   });
 
   test("obfuscates attribute values except protected ones", () => {
-    const input = '<div title="Custom Title" class="test-class" style="color: red;">Content</div>';
+    const input =
+      '<div title="Custom Title" class="test-class" style="color: red;">Content</div>';
     const result = strategy.obfuscateString(input);
 
     expect(result).toMatch(/<div.*<\/div>/);
     expect(result).toContain('class="test-class"');
     expect(result).toContain('style="color: red;"');
-    expect(result).not.toContain('Custom Title');
+    expect(result).not.toContain("Custom Title");
     expect(result).toMatch(/title="[^"]*"/);
   });
 
@@ -51,17 +56,17 @@ describe("HTMLObfuscatorStrategy", () => {
       'style="color: blue;"',
       'contenteditable="false"',
       'data-record-id="123"',
-      'data-record-model-name="Test"'
+      'data-record-model-name="Test"',
     ];
 
-    const input = `<div ${protectedAttrs.join(' ')} custom="should be obfuscated">Content</div>`;
+    const input = `<div ${protectedAttrs.join(" ")} custom="should be obfuscated">Content</div>`;
     const result = strategy.obfuscateString(input);
 
-    protectedAttrs.forEach(attr => {
+    protectedAttrs.forEach((attr) => {
       expect(result).toContain(attr);
     });
-    expect(result).not.toContain('should be obfuscated');
-    expect(result).not.toContain('Content');
+    expect(result).not.toContain("should be obfuscated");
+    expect(result).not.toContain("Content");
   });
 
   test("handles complex HTML with nested qbd-output elements", () => {
@@ -77,10 +82,10 @@ describe("HTMLObfuscatorStrategy", () => {
     `;
     const result = strategy.obfuscateString(input);
 
-    expect(result).toContain('Preserved content');
-    expect(result).toContain('Also preserved');
-    expect(result).not.toContain('Regular text to obfuscate');
-    expect(result).not.toContain('More text to obfuscate');
+    expect(result).toContain("Preserved content");
+    expect(result).toContain("Also preserved");
+    expect(result).not.toContain("Regular text to obfuscate");
+    expect(result).not.toContain("More text to obfuscate");
     expect(result).toContain('<div class="widget">');
     expect(result).toContain('class="qbd-output"');
   });
@@ -97,25 +102,28 @@ describe("HTMLObfuscatorStrategy", () => {
 
     // Should be obfuscated but not equal to original
     expect(result).not.toBe(input);
-    expect(typeof result).toBe('string');
+    expect(typeof result).toBe("string");
   });
 
   test("handles complex real-world HTML document with multiple widget types", () => {
-    const input = '<html><head></head><body><div class="widget" kind="Header"><div class="widget-main"><div class="widget-item"><div>Type: Header</div></div></div><div class="widget-content-container"><div class="widget-content"><table><tbody><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.companyName</span></p></td><td><p style="text-align:left">Export Date: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.informationDate</span></p></td></tr><tr><td><p>Project: <span contenteditable="false" class="qbd-output qbd-output-widget">Project.name</span></p></td><td><p style="text-align:left">Exported By: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.currentUser</span></p></td></tr><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">Document.name</span></p></td><td><p style="text-align:left">Record Data Type: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.dataScope</span></p></td></tr></tbody></table></div></div></div><p></p><div class="widget" kind="Repeater" model="UnitOperation" process="{&quot;id&quot;:1,&quot;name&quot;:&quot;Request Comment&quot;,&quot;description&quot;:&quot;Took&quot;,&quot;site&quot;:&quot;&quot;,&quot;gmp&quot;:false,&quot;scale&quot;:&quot;&quot;,&quot;referencesLinks&quot;:&quot;&quot;,&quot;techTransferEnabled&quot;:null,&quot;integrations&quot;:&quot;&quot;,&quot;currentState&quot;:&quot;Evidence&quot;,&quot;clonedFromVersionId&quot;:null,&quot;clonedFromModel&quot;:&quot;&quot;,&quot;createdByUserId&quot;:5974,&quot;createdAt&quot;:&quot;2025-09-22T05:28:24.000Z&quot;,&quot;updatedAt&quot;:&quot;2025-09-23T07:44:13.000Z&quot;,&quot;deletedAt&quot;:null,&quot;ProjectId&quot;:1,&quot;SupplierId&quot;:null,&quot;SendingId&quot;:null,&quot;LastVersionId&quot;:7,&quot;LastApprovedVersionId&quot;:null,&quot;LastVersionTransitionId&quot;:10,&quot;Supplier&quot;:null,&quot;modelName&quot;:&quot;Process&quot;,&quot;typeCode&quot;:&quot;PR&quot;,&quot;approved&quot;:false,&quot;project&quot;:{&quot;id&quot;:1,&quot;name&quot;:&quot;Magic Pound Cake&quot;,&quot;isDemo&quot;:false,&quot;RMPId&quot;:3,&quot;deletedAt&quot;:null,&quot;riskAssessmentMethod&quot;:null,&quot;productRiskAssessmentType&quot;:&quot;Preliminary Hazards Analysis (PHA)&quot;},&quot;parents&quot;:[],&quot;projectId&quot;:1,&quot;versionId&quot;:7,&quot;cacheDate&quot;:&quot;2025-09-26T16:13:09.000Z&quot;,&quot;cacheId&quot;:2892}"><div class="widget-main"><div class="widget-item"><div>Type: Repeater</div></div><div class="widget-item"><div>Model: Unit Operation</div></div></div><div class="widget-content-container"><div class="widget-content"><p>Unit operation name <span contenteditable="false" class="qbd-output qbd-output-widget">UnitOperation.name</span></p></div></div></div><p></p><p>This is a unit operation <span contenteditable="false" class="qbd-output qbd-output-direct-scope-widget  never-approved" data-record-path="[&quot;UO[name=\'April Institute\']&quot;,&quot;name&quot;]" data-record-id="1" data-record-model-name="UnitOperation" data-record-column-name="name" data-never-approved="true">April Institute</span></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p> </p><div class="widget" kind="Footer"><div class="widget-main"><div class="widget-item"><div>Type: Footer</div></div></div><div class="widget-content-container"><div class="widget-content"><p style="text-align:center">This report was generated with QbDVision Version: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.softwareVersion</span></p><table><tbody><tr><td><p></p></td><td><p style="text-align:center">CONFIDENTIAL INFORMATION</p></td><td><p style="text-align:right">Page <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.pageNumber</span> of  <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.totalPages</span></p></td></tr></tbody></table></div></div></div></body></html>';
+    const input =
+      '<html><head></head><body><div class="widget" kind="Header"><div class="widget-main"><div class="widget-item"><div>Type: Header</div></div></div><div class="widget-content-container"><div class="widget-content"><table><tbody><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.companyName</span></p></td><td><p style="text-align:left">Export Date: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.informationDate</span></p></td></tr><tr><td><p>Project: <span contenteditable="false" class="qbd-output qbd-output-widget">Project.name</span></p></td><td><p style="text-align:left">Exported By: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.currentUser</span></p></td></tr><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">Document.name</span></p></td><td><p style="text-align:left">Record Data Type: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.dataScope</span></p></td></tr></tbody></table></div></div></div><p></p><div class="widget" kind="Repeater" model="UnitOperation" process="{&quot;id&quot;:1,&quot;name&quot;:&quot;Request Comment&quot;,&quot;description&quot;:&quot;Took&quot;,&quot;site&quot;:&quot;&quot;,&quot;gmp&quot;:false,&quot;scale&quot;:&quot;&quot;,&quot;referencesLinks&quot;:&quot;&quot;,&quot;techTransferEnabled&quot;:null,&quot;integrations&quot;:&quot;&quot;,&quot;currentState&quot;:&quot;Evidence&quot;,&quot;clonedFromVersionId&quot;:null,&quot;clonedFromModel&quot;:&quot;&quot;,&quot;createdByUserId&quot;:5974,&quot;createdAt&quot;:&quot;2025-09-22T05:28:24.000Z&quot;,&quot;updatedAt&quot;:&quot;2025-09-23T07:44:13.000Z&quot;,&quot;deletedAt&quot;:null,&quot;ProjectId&quot;:1,&quot;SupplierId&quot;:null,&quot;SendingId&quot;:null,&quot;LastVersionId&quot;:7,&quot;LastApprovedVersionId&quot;:null,&quot;LastVersionTransitionId&quot;:10,&quot;Supplier&quot;:null,&quot;modelName&quot;:&quot;Process&quot;,&quot;typeCode&quot;:&quot;PR&quot;,&quot;approved&quot;:false,&quot;project&quot;:{&quot;id&quot;:1,&quot;name&quot;:&quot;Magic Pound Cake&quot;,&quot;isDemo&quot;:false,&quot;RMPId&quot;:3,&quot;deletedAt&quot;:null,&quot;riskAssessmentMethod&quot;:null,&quot;productRiskAssessmentType&quot;:&quot;Preliminary Hazards Analysis (PHA)&quot;},&quot;parents&quot;:[],&quot;projectId&quot;:1,&quot;versionId&quot;:7,&quot;cacheDate&quot;:&quot;2025-09-26T16:13:09.000Z&quot;,&quot;cacheId&quot;:2892}"><div class="widget-main"><div class="widget-item"><div>Type: Repeater</div></div><div class="widget-item"><div>Model: Unit Operation</div></div></div><div class="widget-content-container"><div class="widget-content"><p>Unit operation name <span contenteditable="false" class="qbd-output qbd-output-widget">UnitOperation.name</span></p></div></div></div><p></p><p>This is a unit operation <span contenteditable="false" class="qbd-output qbd-output-direct-scope-widget  never-approved" data-record-path="[&quot;UO[name=\'April Institute\']&quot;,&quot;name&quot;]" data-record-id="1" data-record-model-name="UnitOperation" data-record-column-name="name" data-never-approved="true">April Institute</span></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p> </p><div class="widget" kind="Footer"><div class="widget-main"><div class="widget-item"><div>Type: Footer</div></div></div><div class="widget-content-container"><div class="widget-content"><p style="text-align:center">This report was generated with QbDVision Version: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.softwareVersion</span></p><table><tbody><tr><td><p></p></td><td><p style="text-align:center">CONFIDENTIAL INFORMATION</p></td><td><p style="text-align:right">Page <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.pageNumber</span> of  <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.totalPages</span></p></td></tr></tbody></table></div></div></div></body></html>';
     const result = strategy.obfuscateString(input);
 
     // Test HTML structure preservation
-    expect(result).toContain('<html>');
-    expect(result).toContain('<head></head>');
-    expect(result).toContain('<body>');
-    expect(result).toContain('</body></html>');
+    expect(result).toContain("<html>");
+    expect(result).toContain("<head></head>");
+    expect(result).toContain("<body>");
+    expect(result).toContain("</body></html>");
 
     // Test protected class attributes are preserved
     expect(result).toContain('class="widget"');
     expect(result).toContain('class="widget-main"');
     expect(result).toContain('class="widget-content"');
     expect(result).toContain('class="qbd-output qbd-output-widget"');
-    expect(result).toContain('class="qbd-output qbd-output-direct-scope-widget  never-approved"');
+    expect(result).toContain(
+      'class="qbd-output qbd-output-direct-scope-widget  never-approved"',
+    );
 
     // Test protected kind attributes are preserved
     expect(result).toContain('kind="Header"');
@@ -140,44 +148,48 @@ describe("HTMLObfuscatorStrategy", () => {
     expect(result).toContain('style="text-align:right"');
 
     // Test qbd-output content is preserved
-    expect(result).toContain('DocBuilderFields.companyName');
-    expect(result).toContain('DocBuilderFields.informationDate');
-    expect(result).toContain('Project.name');
-    expect(result).toContain('DocBuilderFields.currentUser');
-    expect(result).toContain('Document.name');
-    expect(result).toContain('DocBuilderFields.dataScope');
-    expect(result).toContain('UnitOperation.name');
-    expect(result).toContain('DocBuilderFields.softwareVersion');
-    expect(result).toContain('DocBuilderFields.pageNumber');
-    expect(result).toContain('DocBuilderFields.totalPages');
+    expect(result).toContain("DocBuilderFields.companyName");
+    expect(result).toContain("DocBuilderFields.informationDate");
+    expect(result).toContain("Project.name");
+    expect(result).toContain("DocBuilderFields.currentUser");
+    expect(result).toContain("Document.name");
+    expect(result).toContain("DocBuilderFields.dataScope");
+    expect(result).toContain("UnitOperation.name");
+    expect(result).toContain("DocBuilderFields.softwareVersion");
+    expect(result).toContain("DocBuilderFields.pageNumber");
+    expect(result).toContain("DocBuilderFields.totalPages");
 
     // Test qbd-output-direct-scope-widget content is NOT preserved (should be obfuscated)
-    expect(result).not.toContain('April Institute');
+    expect(result).not.toContain("April Institute");
 
     // Test regular text content is obfuscated
-    expect(result).not.toContain('Type: Header');
-    expect(result).not.toContain('Export Date:');
-    expect(result).not.toContain('Project:');
-    expect(result).not.toContain('Exported By:');
-    expect(result).not.toContain('Record Data Type:');
-    expect(result).not.toContain('Type: Repeater');
-    expect(result).not.toContain('Model: Unit Operation');
-    expect(result).not.toContain('Unit operation name');
-    expect(result).not.toContain('This is a unit operation');
-    expect(result).not.toContain('Type: Footer');
-    expect(result).not.toContain('This report was generated with QbDVision Version:');
-    expect(result).not.toContain('CONFIDENTIAL INFORMATION');
+    expect(result).not.toContain("Type: Header");
+    expect(result).not.toContain("Export Date:");
+    expect(result).not.toContain("Project:");
+    expect(result).not.toContain("Exported By:");
+    expect(result).not.toContain("Record Data Type:");
+    expect(result).not.toContain("Type: Repeater");
+    expect(result).not.toContain("Model: Unit Operation");
+    expect(result).not.toContain("Unit operation name");
+    expect(result).not.toContain("This is a unit operation");
+    expect(result).not.toContain("Type: Footer");
+    expect(result).not.toContain(
+      "This report was generated with QbDVision Version:",
+    );
+    expect(result).not.toContain("CONFIDENTIAL INFORMATION");
 
     // Test process attribute should be obfuscated (not in protected list)
-    expect(result).not.toContain('Request Comment');
-    expect(result).not.toContain('Magic Pound Cake');
-    expect(result).not.toContain('Preliminary Hazards Analysis (PHA)');
+    expect(result).not.toContain("Request Comment");
+    expect(result).not.toContain("Magic Pound Cake");
+    expect(result).not.toContain("Preliminary Hazards Analysis (PHA)");
   });
 
   test("obfuscates process attribute object values while preserving protected keys", () => {
     const input = `<div process='{"id":1,"amount":2,"name":"Test Process","modelName":"Process","typeCode":"PR","description":"This should be obfuscated","site":"Test Site","class":"widget-class"}'>Content</div>`;
     const result = strategy.obfuscateString(input);
-    const processObj = JSON.parse(parse(result).firstChild.getAttribute('process'));
+    const processObj = JSON.parse(
+      parse(result).firstChild.getAttribute("process"),
+    );
 
     // Protected keys should have their original values preserved
     expect(processObj.modelName).toBe("Process");
@@ -194,19 +206,21 @@ describe("HTMLObfuscatorStrategy", () => {
     expect(processObj.amount).toBe(2);
 
     // Should still have the same keys
-    expect(processObj).toHaveProperty('id');
-    expect(processObj).toHaveProperty('name');
-    expect(processObj).toHaveProperty('modelName');
-    expect(processObj).toHaveProperty('typeCode');
-    expect(processObj).toHaveProperty('description');
-    expect(processObj).toHaveProperty('site');
-    expect(processObj).toHaveProperty('class');
+    expect(processObj).toHaveProperty("id");
+    expect(processObj).toHaveProperty("name");
+    expect(processObj).toHaveProperty("modelName");
+    expect(processObj).toHaveProperty("typeCode");
+    expect(processObj).toHaveProperty("description");
+    expect(processObj).toHaveProperty("site");
+    expect(processObj).toHaveProperty("class");
   });
 
   test("handles nested objects in process attribute", () => {
     const input = `<div process='{"project":{"id":1,"amount":3,"name":"Magic Cake","modelName":"Project","description":"Test Description"},"modelName":"Process","name":"Main Process"}'>Content</div>`;
     const result = strategy.obfuscateString(input);
-    const processObj = JSON.parse(parse(result).firstChild.getAttribute('process'));
+    const processObj = JSON.parse(
+      parse(result).firstChild.getAttribute("process"),
+    );
 
     // Top-level protected attributes should be preserved
     expect(processObj.modelName).toBe("Process");
@@ -220,5 +234,181 @@ describe("HTMLObfuscatorStrategy", () => {
     // Nested object non-protected attributes should be obfuscated
     expect(processObj.project.name).not.toBe("Magic Cake");
     expect(processObj.project.description).not.toBe("Test Description");
+  });
+
+  test("keeps the filters attribute valid JSON and only obfuscates its text values", () => {
+    const filters =
+      '[{"model":"ProcessParameter","isAndFilter":true,' +
+      '"field":"ProcessParameter.name","operator":"=","value":"pH"}]';
+    const input = `<div class="widget" kind="Repeater" filters='${filters}'>x</div>`;
+
+    const result = strategy.obfuscateString(input);
+    const value = parse(result).querySelector("div").getAttribute("filters");
+
+    // Document Builder broke here. Obfuscating the attribute as plain text turned the boolean
+    // true into a bare word, so the attribute stopped being valid JSON.
+    const parsed = JSON.parse(value);
+
+    expect(parsed[0].isAndFilter).toBe(true);
+    expect(parsed[0].field).toBe("ProcessParameter.name");
+    expect(parsed[0].operator).toBe("=");
+    expect(parsed[0].value).not.toBe("pH");
+  });
+
+  test("preserves attribute values the app reads instead of displays", () => {
+    const input =
+      '<div selected="true" dynamiclist="false" level="1" width="120px" ' +
+      'uuid="1e5b3c4a-2f11-4c9d-8a77-9b2e0d4f6a13" title="Batch release report">x</div>';
+
+    const node = parse(strategy.obfuscateString(input)).querySelector("div");
+
+    expect(node.getAttribute("selected")).toBe("true");
+    expect(node.getAttribute("dynamiclist")).toBe("false");
+    expect(node.getAttribute("level")).toBe("1");
+    expect(node.getAttribute("width")).toBe("120px");
+    expect(node.getAttribute("uuid")).toBe(
+      "1e5b3c4a-2f11-4c9d-8a77-9b2e0d4f6a13",
+    );
+    // Real text is still obfuscated.
+    expect(node.getAttribute("title")).not.toBe("Batch release report");
+  });
+
+  test("obfuscates only the record name inside data-record-path", () => {
+    // The dump stores this attribute with encoded quotes, so the test uses the same form.
+    const path =
+      "[&quot;PP[name='Fermentation']&quot;,&quot;UO[name='Harvest']&quot;,&quot;description&quot;]";
+    const input = `<span class="qbd-output" data-record-path="${path}">x</span>`;
+
+    const result = strategy.obfuscateString(input);
+    const value = parse(result)
+      .querySelector("span")
+      .getAttribute("data-record-path");
+    const steps = JSON.parse(value);
+
+    expect(steps).toHaveLength(3);
+    // Type codes and the trailing field name are schema, so they survive.
+    expect(steps[0]).toMatch(/^PP\[name='.+'\]$/);
+    expect(steps[1]).toMatch(/^UO\[name='.+'\]$/);
+    expect(steps[2]).toBe("description");
+    // Record names are customer data, so they are replaced.
+    expect(steps[0]).not.toContain("Fermentation");
+    expect(steps[1]).not.toContain("Harvest");
+  });
+
+  test("gives a record name the same replacement everywhere it appears", () => {
+    const path = "[&quot;PP[name='Fermentation']&quot;,&quot;name&quot;]";
+    const input =
+      `<span data-record-path="${path}"></span>` + `<p>Fermentation</p>`;
+
+    const root = parse(strategy.obfuscateString(input));
+    const pathName = JSON.parse(
+      root.querySelector("span").getAttribute("data-record-path"),
+    )[0].match(/name='(.*)'/)[1];
+
+    expect(root.querySelector("p").text).toBe(pathName);
+  });
+
+  test("matches protected attribute names case insensitively", () => {
+    const input = '<div modelName="Project" typeCode="PRJ">x</div>';
+
+    const node = parse(strategy.obfuscateString(input)).querySelector("div");
+
+    expect(node.getAttribute("modelname")).toBe("Project");
+    expect(node.getAttribute("typecode")).toBe("PRJ");
+  });
+});
+
+// node-html-parser 7.x rebuilt every attribute of an element after one setAttribute call
+// and stripped backslashes while doing it. That turned the \n and \" escapes inside JSON
+// attributes into raw newlines and bare quotes, which broke JSON.parse in Document
+// Builder. Version 9 keeps the bytes as they are. These tests pin that, and they pin the
+// shared dictionary that keeps the copies inside document HTML equal to the column values.
+describe("data-record-sub-model-data", () => {
+  test("obfuscates customer text, keeps join keys, and stays valid JSON", () => {
+    const shared = new DictionaryObfuscatorStrategy();
+    const strategy = new HTMLObfuscatorStrategy(shared);
+    const link = {
+      uuid: "cf40e9ac",
+      linkType: "Attachment",
+      fileName: "Report v1.pdf",
+    };
+    const nestedLinks = JSON.stringify([
+      { uuid: "bcef9bfa", linkType: "Link" },
+    ]);
+    const subModelData = JSON.stringify({
+      id: 24508,
+      uuid: "336cb4e7-3eaa-4af9-ba4f-eae34a54fb3f",
+      group: "Processing",
+      label: "Parameter Range",
+      isDefault: true,
+      targetJustification: "Not Less Than 0.5 hours. \nNot More Than 6 hours.",
+      acceptanceCriteriaLinks: nestedLinks,
+      link,
+    });
+    const encoded = subModelData.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+    const path = "[&quot;PP[name='Fermentation']&quot;,&quot;lowerLimit&quot;]";
+    const input =
+      '<span class="qbd-output qbd-output-direct-scope-widget"' +
+      ` data-record-path="${path}"` +
+      ' data-record-sub-model-name="AcceptanceCriteriaRange"' +
+      ` data-record-sub-model-data="${encoded}">0.5</span>`;
+
+    const result = strategy.obfuscateString(input);
+    const value = parse(result)
+      .querySelector("span")
+      .getAttribute("data-record-sub-model-data");
+    const parsed = JSON.parse(value);
+
+    // Join keys and structure survive.
+    expect(parsed.id).toBe(24508);
+    expect(parsed.uuid).toBe("336cb4e7-3eaa-4af9-ba4f-eae34a54fb3f");
+    expect(parsed.isDefault).toBe(true);
+    // The app looks up sub records by group and label, so both must get the same
+    // replacement as the database columns, which share this dictionary.
+    expect(parsed.group).toBe(shared.obfuscateString("Processing"));
+    expect(parsed.label).toBe(shared.obfuscateString("Parameter Range"));
+    // Free text is replaced but keeps its line break, so the escapes stay valid JSON.
+    expect(parsed.targetJustification).not.toContain("Not Less Than");
+    expect(parsed.targetJustification).toContain("\n");
+    // Link data mirrors database JSON columns that the column rules skip, so it stays as is.
+    expect(parsed.acceptanceCriteriaLinks).toBe(nestedLinks);
+    expect(parsed.link).toEqual(link);
+  });
+
+  test("filters targetValue matches the column obfuscation through the shared dictionary", () => {
+    const shared = new DictionaryObfuscatorStrategy();
+    const strategy = new HTMLObfuscatorStrategy(shared);
+    const filters =
+      '[{"isAndFilter":true,"attribute":"ProcessParameter.name",' +
+      '"operator":"=","targetValue":"Fermentation Temperature"}]';
+    const input = `<div class="widget" filters='${filters}'>x</div>`;
+
+    const value = parse(strategy.obfuscateString(input))
+      .querySelector("div")
+      .getAttribute("filters");
+
+    // The backend runs this filter against the ProcessParameter name column, so the
+    // obfuscated filter value must equal the obfuscated column value.
+    expect(JSON.parse(value)[0].targetValue).toBe(
+      shared.obfuscateString("Fermentation Temperature"),
+    );
+  });
+
+  test("the strategy map wires one dictionary for columns and html", () => {
+    const columnValue =
+      ObfuscatorStrategyMap.dictionaryObfuscator.obfuscateString(
+        "Quality Range",
+      );
+    const html =
+      '<span data-record-sub-model-data="{&quot;group&quot;:&quot;Quality Range&quot;}">x</span>';
+
+    const out = ObfuscatorStrategyMap.htmlObfuscator.obfuscateString(html);
+    const parsed = JSON.parse(
+      parse(out)
+        .querySelector("span")
+        .getAttribute("data-record-sub-model-data"),
+    );
+
+    expect(parsed.group).toBe(columnValue);
   });
 });

--- a/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/HTMLObfuscatorStrategy.test.js
@@ -20,8 +20,7 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("preserves text in elements with qbd-output class", () => {
-    const input =
-      '<p>This should be obfuscated</p><span class="qbd-output">This should be preserved</span>';
+    const input = `<p>This should be obfuscated</p><span class="qbd-output">This should be preserved</span>`;
     const result = strategy.obfuscateString(input);
 
     expect(result).toContain("This should be preserved");
@@ -29,8 +28,7 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("not preserves text in elements with qbd-output-direct-scope-widget class", () => {
-    const input =
-      '<p>This should be obfuscated</p><span class="qbd-output qbd-output-direct-scope-widget">This should not be preserved</span>';
+    const input = `<p>This should be obfuscated</p><span class="qbd-output qbd-output-direct-scope-widget">This should not be preserved</span>`;
     const result = strategy.obfuscateString(input);
 
     expect(result).not.toContain("This should not be preserved");
@@ -38,25 +36,24 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("obfuscates attribute values except protected ones", () => {
-    const input =
-      '<div title="Custom Title" class="test-class" style="color: red;">Content</div>';
+    const input = `<div title="Custom Title" class="test-class" style="color: red;">Content</div>`;
     const result = strategy.obfuscateString(input);
 
     expect(result).toMatch(/<div.*<\/div>/);
-    expect(result).toContain('class="test-class"');
-    expect(result).toContain('style="color: red;"');
+    expect(result).toContain(`class="test-class"`);
+    expect(result).toContain(`style="color: red;"`);
     expect(result).not.toContain("Custom Title");
     expect(result).toMatch(/title="[^"]*"/);
   });
 
   test("preserves protected attributes", () => {
     const protectedAttrs = [
-      'class="widget"',
-      'kind="Repeater"',
-      'style="color: blue;"',
-      'contenteditable="false"',
-      'data-record-id="123"',
-      'data-record-model-name="Test"',
+      `class="widget"`,
+      `kind="Repeater"`,
+      `style="color: blue;"`,
+      `contenteditable="false"`,
+      `data-record-id="123"`,
+      `data-record-model-name="Test"`,
     ];
 
     const input = `<div ${protectedAttrs.join(" ")} custom="should be obfuscated">Content</div>`;
@@ -86,8 +83,8 @@ describe("HTMLObfuscatorStrategy", () => {
     expect(result).toContain("Also preserved");
     expect(result).not.toContain("Regular text to obfuscate");
     expect(result).not.toContain("More text to obfuscate");
-    expect(result).toContain('<div class="widget">');
-    expect(result).toContain('class="qbd-output"');
+    expect(result).toContain(`<div class="widget">`);
+    expect(result).toContain(`class="qbd-output"`);
   });
 
   test("handles empty or null input", () => {
@@ -106,8 +103,7 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("handles complex real-world HTML document with multiple widget types", () => {
-    const input =
-      '<html><head></head><body><div class="widget" kind="Header"><div class="widget-main"><div class="widget-item"><div>Type: Header</div></div></div><div class="widget-content-container"><div class="widget-content"><table><tbody><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.companyName</span></p></td><td><p style="text-align:left">Export Date: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.informationDate</span></p></td></tr><tr><td><p>Project: <span contenteditable="false" class="qbd-output qbd-output-widget">Project.name</span></p></td><td><p style="text-align:left">Exported By: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.currentUser</span></p></td></tr><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">Document.name</span></p></td><td><p style="text-align:left">Record Data Type: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.dataScope</span></p></td></tr></tbody></table></div></div></div><p></p><div class="widget" kind="Repeater" model="UnitOperation" process="{&quot;id&quot;:1,&quot;name&quot;:&quot;Request Comment&quot;,&quot;description&quot;:&quot;Took&quot;,&quot;site&quot;:&quot;&quot;,&quot;gmp&quot;:false,&quot;scale&quot;:&quot;&quot;,&quot;referencesLinks&quot;:&quot;&quot;,&quot;techTransferEnabled&quot;:null,&quot;integrations&quot;:&quot;&quot;,&quot;currentState&quot;:&quot;Evidence&quot;,&quot;clonedFromVersionId&quot;:null,&quot;clonedFromModel&quot;:&quot;&quot;,&quot;createdByUserId&quot;:5974,&quot;createdAt&quot;:&quot;2025-09-22T05:28:24.000Z&quot;,&quot;updatedAt&quot;:&quot;2025-09-23T07:44:13.000Z&quot;,&quot;deletedAt&quot;:null,&quot;ProjectId&quot;:1,&quot;SupplierId&quot;:null,&quot;SendingId&quot;:null,&quot;LastVersionId&quot;:7,&quot;LastApprovedVersionId&quot;:null,&quot;LastVersionTransitionId&quot;:10,&quot;Supplier&quot;:null,&quot;modelName&quot;:&quot;Process&quot;,&quot;typeCode&quot;:&quot;PR&quot;,&quot;approved&quot;:false,&quot;project&quot;:{&quot;id&quot;:1,&quot;name&quot;:&quot;Magic Pound Cake&quot;,&quot;isDemo&quot;:false,&quot;RMPId&quot;:3,&quot;deletedAt&quot;:null,&quot;riskAssessmentMethod&quot;:null,&quot;productRiskAssessmentType&quot;:&quot;Preliminary Hazards Analysis (PHA)&quot;},&quot;parents&quot;:[],&quot;projectId&quot;:1,&quot;versionId&quot;:7,&quot;cacheDate&quot;:&quot;2025-09-26T16:13:09.000Z&quot;,&quot;cacheId&quot;:2892}"><div class="widget-main"><div class="widget-item"><div>Type: Repeater</div></div><div class="widget-item"><div>Model: Unit Operation</div></div></div><div class="widget-content-container"><div class="widget-content"><p>Unit operation name <span contenteditable="false" class="qbd-output qbd-output-widget">UnitOperation.name</span></p></div></div></div><p></p><p>This is a unit operation <span contenteditable="false" class="qbd-output qbd-output-direct-scope-widget  never-approved" data-record-path="[&quot;UO[name=\'April Institute\']&quot;,&quot;name&quot;]" data-record-id="1" data-record-model-name="UnitOperation" data-record-column-name="name" data-never-approved="true">April Institute</span></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p> </p><div class="widget" kind="Footer"><div class="widget-main"><div class="widget-item"><div>Type: Footer</div></div></div><div class="widget-content-container"><div class="widget-content"><p style="text-align:center">This report was generated with QbDVision Version: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.softwareVersion</span></p><table><tbody><tr><td><p></p></td><td><p style="text-align:center">CONFIDENTIAL INFORMATION</p></td><td><p style="text-align:right">Page <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.pageNumber</span> of  <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.totalPages</span></p></td></tr></tbody></table></div></div></div></body></html>';
+    const input = `<html><head></head><body><div class="widget" kind="Header"><div class="widget-main"><div class="widget-item"><div>Type: Header</div></div></div><div class="widget-content-container"><div class="widget-content"><table><tbody><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.companyName</span></p></td><td><p style="text-align:left">Export Date: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.informationDate</span></p></td></tr><tr><td><p>Project: <span contenteditable="false" class="qbd-output qbd-output-widget">Project.name</span></p></td><td><p style="text-align:left">Exported By: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.currentUser</span></p></td></tr><tr><td><p><span contenteditable="false" class="qbd-output qbd-output-widget">Document.name</span></p></td><td><p style="text-align:left">Record Data Type: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.dataScope</span></p></td></tr></tbody></table></div></div></div><p></p><div class="widget" kind="Repeater" model="UnitOperation" process="{&quot;id&quot;:1,&quot;name&quot;:&quot;Request Comment&quot;,&quot;description&quot;:&quot;Took&quot;,&quot;site&quot;:&quot;&quot;,&quot;gmp&quot;:false,&quot;scale&quot;:&quot;&quot;,&quot;referencesLinks&quot;:&quot;&quot;,&quot;techTransferEnabled&quot;:null,&quot;integrations&quot;:&quot;&quot;,&quot;currentState&quot;:&quot;Evidence&quot;,&quot;clonedFromVersionId&quot;:null,&quot;clonedFromModel&quot;:&quot;&quot;,&quot;createdByUserId&quot;:5974,&quot;createdAt&quot;:&quot;2025-09-22T05:28:24.000Z&quot;,&quot;updatedAt&quot;:&quot;2025-09-23T07:44:13.000Z&quot;,&quot;deletedAt&quot;:null,&quot;ProjectId&quot;:1,&quot;SupplierId&quot;:null,&quot;SendingId&quot;:null,&quot;LastVersionId&quot;:7,&quot;LastApprovedVersionId&quot;:null,&quot;LastVersionTransitionId&quot;:10,&quot;Supplier&quot;:null,&quot;modelName&quot;:&quot;Process&quot;,&quot;typeCode&quot;:&quot;PR&quot;,&quot;approved&quot;:false,&quot;project&quot;:{&quot;id&quot;:1,&quot;name&quot;:&quot;Magic Pound Cake&quot;,&quot;isDemo&quot;:false,&quot;RMPId&quot;:3,&quot;deletedAt&quot;:null,&quot;riskAssessmentMethod&quot;:null,&quot;productRiskAssessmentType&quot;:&quot;Preliminary Hazards Analysis (PHA)&quot;},&quot;parents&quot;:[],&quot;projectId&quot;:1,&quot;versionId&quot;:7,&quot;cacheDate&quot;:&quot;2025-09-26T16:13:09.000Z&quot;,&quot;cacheId&quot;:2892}"><div class="widget-main"><div class="widget-item"><div>Type: Repeater</div></div><div class="widget-item"><div>Model: Unit Operation</div></div></div><div class="widget-content-container"><div class="widget-content"><p>Unit operation name <span contenteditable="false" class="qbd-output qbd-output-widget">UnitOperation.name</span></p></div></div></div><p></p><p>This is a unit operation <span contenteditable="false" class="qbd-output qbd-output-direct-scope-widget  never-approved" data-record-path="[&quot;UO[name='April Institute']&quot;,&quot;name&quot;]" data-record-id="1" data-record-model-name="UnitOperation" data-record-column-name="name" data-never-approved="true">April Institute</span></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p></p><p> </p><div class="widget" kind="Footer"><div class="widget-main"><div class="widget-item"><div>Type: Footer</div></div></div><div class="widget-content-container"><div class="widget-content"><p style="text-align:center">This report was generated with QbDVision Version: <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.softwareVersion</span></p><table><tbody><tr><td><p></p></td><td><p style="text-align:center">CONFIDENTIAL INFORMATION</p></td><td><p style="text-align:right">Page <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.pageNumber</span> of  <span contenteditable="false" class="qbd-output qbd-output-widget">DocBuilderFields.totalPages</span></p></td></tr></tbody></table></div></div></div></body></html>`;
     const result = strategy.obfuscateString(input);
 
     // Test HTML structure preservation
@@ -117,35 +113,35 @@ describe("HTMLObfuscatorStrategy", () => {
     expect(result).toContain("</body></html>");
 
     // Test protected class attributes are preserved
-    expect(result).toContain('class="widget"');
-    expect(result).toContain('class="widget-main"');
-    expect(result).toContain('class="widget-content"');
-    expect(result).toContain('class="qbd-output qbd-output-widget"');
+    expect(result).toContain(`class="widget"`);
+    expect(result).toContain(`class="widget-main"`);
+    expect(result).toContain(`class="widget-content"`);
+    expect(result).toContain(`class="qbd-output qbd-output-widget"`);
     expect(result).toContain(
-      'class="qbd-output qbd-output-direct-scope-widget  never-approved"',
+      `class="qbd-output qbd-output-direct-scope-widget  never-approved"`,
     );
 
     // Test protected kind attributes are preserved
-    expect(result).toContain('kind="Header"');
-    expect(result).toContain('kind="Repeater"');
-    expect(result).toContain('kind="Footer"');
+    expect(result).toContain(`kind="Header"`);
+    expect(result).toContain(`kind="Repeater"`);
+    expect(result).toContain(`kind="Footer"`);
 
     // Test protected model attribute is preserved
-    expect(result).toContain('model="UnitOperation"');
+    expect(result).toContain(`model="UnitOperation"`);
 
     // Test protected contenteditable attributes are preserved
-    expect(result).toContain('contenteditable="false"');
+    expect(result).toContain(`contenteditable="false"`);
 
     // Test protected data-* attributes are preserved
-    expect(result).toContain('data-record-id="1"');
-    expect(result).toContain('data-record-model-name="UnitOperation"');
-    expect(result).toContain('data-record-column-name="name"');
-    expect(result).toContain('data-never-approved="true"');
+    expect(result).toContain(`data-record-id="1"`);
+    expect(result).toContain(`data-record-model-name="UnitOperation"`);
+    expect(result).toContain(`data-record-column-name="name"`);
+    expect(result).toContain(`data-never-approved="true"`);
 
     // Test protected style attributes are preserved
-    expect(result).toContain('style="text-align:left"');
-    expect(result).toContain('style="text-align:center"');
-    expect(result).toContain('style="text-align:right"');
+    expect(result).toContain(`style="text-align:left"`);
+    expect(result).toContain(`style="text-align:center"`);
+    expect(result).toContain(`style="text-align:right"`);
 
     // Test qbd-output content is preserved
     expect(result).toContain("DocBuilderFields.companyName");
@@ -238,8 +234,8 @@ describe("HTMLObfuscatorStrategy", () => {
 
   test("keeps the filters attribute valid JSON and only obfuscates its text values", () => {
     const filters =
-      '[{"model":"ProcessParameter","isAndFilter":true,' +
-      '"field":"ProcessParameter.name","operator":"=","value":"pH"}]';
+      `[{"model":"ProcessParameter","isAndFilter":true,` +
+      `"field":"ProcessParameter.name","operator":"=","value":"pH"}]`;
     const input = `<div class="widget" kind="Repeater" filters='${filters}'>x</div>`;
 
     const result = strategy.obfuscateString(input);
@@ -255,10 +251,33 @@ describe("HTMLObfuscatorStrategy", () => {
     expect(parsed[0].value).not.toBe("pH");
   });
 
+  test("keeps filter settings the app reads and only replaces the typed value", () => {
+    const shared = new DictionaryObfuscatorStrategy();
+    const strategy = new HTMLObfuscatorStrategy(shared);
+    const filters =
+      `[{"model":"ProcessParameter","subModel":"AcceptanceCriteriaRange",` +
+      `"attribute":"name","operator":"contains","targetValue":"Fermentation"}]`;
+    const input = `<div class="widget" kind="Repeater" filters='${filters}'>x</div>`;
+
+    const parsed = JSON.parse(
+      parse(strategy.obfuscateString(input))
+        .querySelector("div")
+        .getAttribute("filters"),
+    )[0];
+
+    // Filter settings read like ordinary words, so they used to be replaced. The widget then
+    // failed with "Unknown operator" and never rendered.
+    expect(parsed.operator).toBe("contains");
+    expect(parsed.subModel).toBe("AcceptanceCriteriaRange");
+    expect(parsed.attribute).toBe("name");
+    // The value the customer typed is still replaced, and matches the column obfuscation.
+    expect(parsed.targetValue).toBe(shared.obfuscateString("Fermentation"));
+  });
+
   test("preserves attribute values the app reads instead of displays", () => {
     const input =
-      '<div selected="true" dynamiclist="false" level="1" width="120px" ' +
-      'uuid="1e5b3c4a-2f11-4c9d-8a77-9b2e0d4f6a13" title="Batch release report">x</div>';
+      `<div selected="true" dynamiclist="false" level="1" width="120px" ` +
+      `uuid="1e5b3c4a-2f11-4c9d-8a77-9b2e0d4f6a13" title="Batch release report">x</div>`;
 
     const node = parse(strategy.obfuscateString(input)).querySelector("div");
 
@@ -309,7 +328,7 @@ describe("HTMLObfuscatorStrategy", () => {
   });
 
   test("matches protected attribute names case insensitively", () => {
-    const input = '<div modelName="Project" typeCode="PRJ">x</div>';
+    const input = `<div modelName="Project" typeCode="PRJ">x</div>`;
 
     const node = parse(strategy.obfuscateString(input)).querySelector("div");
 
@@ -348,9 +367,9 @@ describe("data-record-sub-model-data", () => {
     const encoded = subModelData.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
     const path = "[&quot;PP[name='Fermentation']&quot;,&quot;lowerLimit&quot;]";
     const input =
-      '<span class="qbd-output qbd-output-direct-scope-widget"' +
+      `<span class="qbd-output qbd-output-direct-scope-widget"` +
       ` data-record-path="${path}"` +
-      ' data-record-sub-model-name="AcceptanceCriteriaRange"' +
+      ` data-record-sub-model-name="AcceptanceCriteriaRange"` +
       ` data-record-sub-model-data="${encoded}">0.5</span>`;
 
     const result = strategy.obfuscateString(input);
@@ -379,8 +398,8 @@ describe("data-record-sub-model-data", () => {
     const shared = new DictionaryObfuscatorStrategy();
     const strategy = new HTMLObfuscatorStrategy(shared);
     const filters =
-      '[{"isAndFilter":true,"attribute":"ProcessParameter.name",' +
-      '"operator":"=","targetValue":"Fermentation Temperature"}]';
+      `[{"isAndFilter":true,"attribute":"ProcessParameter.name",` +
+      `"operator":"=","targetValue":"Fermentation Temperature"}]`;
     const input = `<div class="widget" filters='${filters}'>x</div>`;
 
     const value = parse(strategy.obfuscateString(input))
@@ -399,8 +418,7 @@ describe("data-record-sub-model-data", () => {
       ObfuscatorStrategyMap.dictionaryObfuscator.obfuscateString(
         "Quality Range",
       );
-    const html =
-      '<span data-record-sub-model-data="{&quot;group&quot;:&quot;Quality Range&quot;}">x</span>';
+    const html = `<span data-record-sub-model-data="{&quot;group&quot;:&quot;Quality Range&quot;}">x</span>`;
 
     const out = ObfuscatorStrategyMap.htmlObfuscator.obfuscateString(html);
     const parsed = JSON.parse(

--- a/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
@@ -1,0 +1,99 @@
+import { LinkObfuscatorStrategy } from "../../src/classes/obfuscators/LinkObfuscatorStrategy.js";
+import { HTMLObfuscatorStrategy } from "../../src/classes/obfuscators/HTMLObfuscatorStrategy.js";
+import { parse } from "node-html-parser";
+
+describe("LinkObfuscatorStrategy", () => {
+  let strategy;
+
+  beforeEach(() => {
+    strategy = new LinkObfuscatorStrategy();
+  });
+
+  test("replaces a real URL with a working dummy URL", () => {
+    const input = JSON.stringify([
+      {
+        uuid: "bcef9bfa-ed50-42c3-873d-72fd8d8981f9",
+        linkType: "Link",
+        link: "https://lilly.veevavault.com/ui/doc_info/2833497",
+      },
+    ]);
+
+    const [out] = JSON.parse(strategy.obfuscateString(input));
+
+    expect(out.link).toBe("https://google.com");
+    // The app reads these, and neither one holds customer data.
+    expect(out.uuid).toBe("bcef9bfa-ed50-42c3-873d-72fd8d8981f9");
+    expect(out.linkType).toBe("Link");
+  });
+
+  test("replaces the customer file name but keeps the extension", () => {
+    const input = JSON.stringify([
+      { linkType: "Attachment", fileName: "Lilly-Logo.svg.png" },
+    ]);
+
+    const [out] = JSON.parse(strategy.obfuscateString(input));
+
+    expect(out.fileName).toBe("attachment.png");
+  });
+
+  test("keeps storage keys unique so images do not collapse onto one another", () => {
+    // The app looks images up by S3TmpKey. A single fixed dummy would point every image at the
+    // same entry, so the ids in the middle of the path have to survive.
+    const input = JSON.stringify([
+      { S3TmpKey: "client_qa_LillyQA/091b85d5-cf06/Lilly-Logo.svg.png" },
+      { S3TmpKey: "client_qa_LillyQA/e2a6399b-56b7/process_flow_map.png" },
+    ]);
+
+    const [first, second] = JSON.parse(strategy.obfuscateString(input));
+
+    expect(first.S3TmpKey).toBe("obfuscated/091b85d5-cf06/attachment.png");
+    expect(second.S3TmpKey).toBe("obfuscated/e2a6399b-56b7/attachment.png");
+    expect(first.S3TmpKey).not.toBe(second.S3TmpKey);
+    expect(strategy.obfuscateString(input)).not.toContain("LillyQA");
+  });
+
+  test("reaches link fields nested inside an object", () => {
+    const input = JSON.stringify({
+      link: { linkType: "Attachment", fileName: "Equipment Flow Chart.png" },
+    });
+
+    const out = JSON.parse(strategy.obfuscateString(input));
+
+    expect(out.link.fileName).toBe("attachment.png");
+  });
+
+  test("leaves a value alone when it is not JSON", () => {
+    expect(strategy.obfuscateString("not json at all")).toBe("not json at all");
+    expect(strategy.obfuscateString("")).toBe("");
+    expect(strategy.obfuscateString(null)).toBe(null);
+  });
+
+  test("gives a column and its copy inside document HTML the same value", () => {
+    // This is the whole point. parser.js keys the image map by the column's S3TmpKey and
+    // image_parser.js looks it up with the S3TmpKey from the HTML attribute, so if the two paths
+    // disagreed every image in the document would stop resolving.
+    const fileData = {
+      uuid: "cf40e9ac-1d22-4a7f-9f4e-77b0c1a9e551",
+      linkType: "Attachment",
+      fileName: "Process Flow 1.png",
+      S3TmpKey: "client_qa_LillyQA/64a64cc4-001f/Process Flow 1.png",
+    };
+
+    const fromColumn = JSON.parse(
+      strategy.obfuscateString(JSON.stringify([fileData])),
+    )[0];
+
+    const encoded = JSON.stringify(fileData)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;");
+    const html = `<img filedata="${encoded}" />`;
+    const fromHtml = JSON.parse(
+      parse(new HTMLObfuscatorStrategy().obfuscateString(html))
+        .querySelector("img")
+        .getAttribute("filedata"),
+    );
+
+    expect(fromHtml.S3TmpKey).toBe(fromColumn.S3TmpKey);
+    expect(fromHtml.fileName).toBe(fromColumn.fileName);
+  });
+});

--- a/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
@@ -1,6 +1,13 @@
 import { LinkObfuscatorStrategy } from "../../src/classes/obfuscators/LinkObfuscatorStrategy.js";
 import { HTMLObfuscatorStrategy } from "../../src/classes/obfuscators/HTMLObfuscatorStrategy.js";
+import { DictionaryObfuscatorStrategy } from "../../src/classes/obfuscators/DictionaryObfuscatorStrategy.js";
+import Obfuscator from "../../src/classes/Obfuscator.js";
 import { parse } from "node-html-parser";
+import { fileURLToPath } from "url";
+
+const TEMPLATE_CONFIG = fileURLToPath(
+  new URL("../../obfuscationCfg-template.yaml", import.meta.url),
+);
 
 describe("LinkObfuscatorStrategy", () => {
   let strategy;
@@ -95,6 +102,158 @@ describe("LinkObfuscatorStrategy", () => {
 
     expect(fromHtml.S3TmpKey).toBe(fromColumn.S3TmpKey);
     expect(fromHtml.fileName).toBe(fromColumn.fileName);
+  });
+});
+
+describe("link columns are found by name, not by a list", () => {
+  const obfuscator = new Obfuscator({ dialect: "mysql" }, TEMPLATE_CONFIG);
+
+  test("covers every column whose name ends in links", () => {
+    // riskLinks used to ship in plain text because no config rule named it.
+    const columns = [
+      "links",
+      "riskLinks",
+      "riskControlLinks",
+      "detailedRiskLinks",
+      "techTransferLinks",
+      "acceptanceCriteriaLinks",
+      "uploadImageLinks",
+    ];
+
+    for (const column of columns) {
+      expect(
+        obfuscator.getLinkRule(column, "string", undefined, undefined),
+      ).toEqual({
+        obfuscationRule: "linkObfuscator",
+        ignorePattern: "",
+      });
+    }
+  });
+
+  test("leaves other columns and other types alone", () => {
+    expect(
+      obfuscator.getLinkRule("name", "string", undefined, undefined),
+    ).toBeUndefined();
+    expect(
+      obfuscator.getLinkRule("linkedRecordId", "string", undefined, undefined),
+    ).toBeUndefined();
+    expect(
+      obfuscator.getLinkRule("riskLinks", "int(11)", undefined, undefined),
+    ).toBeUndefined();
+  });
+
+  test("a rule written for the column wins", () => {
+    const written = { name: "riskLinks", obfuscationRule: "noObfuscator" };
+
+    expect(
+      obfuscator.getLinkRule("riskLinks", "string", written, undefined),
+    ).toBeUndefined();
+    expect(
+      obfuscator.getLinkRule("riskLinks", "string", undefined, written),
+    ).toBeUndefined();
+  });
+});
+
+describe("everything inside a link is replaced unless the app reads it", () => {
+  let strategy;
+
+  beforeEach(() => {
+    strategy = new LinkObfuscatorStrategy();
+  });
+
+  test("replaces the upload trace URL, which carries the bucket, the schema and an AWS token", () => {
+    const input = JSON.stringify([
+      {
+        S3TmpKey: "client_qa_LillyQA/091b85d5-cf06/Lilly-Logo.svg.png",
+        xhr: {
+          __sentry_xhr_v3__: {
+            method: "PUT",
+            url: "https://ent-lily-qa-tmpdocument-attachments.s3.amazonaws.com/client_qa_LillyQA/091b85d5-cf06/Lilly-Logo.svg.png?X-Amz-Credential=ASIAXYKJVD2OJCGGRZ6N",
+          },
+        },
+      },
+    ]);
+
+    const output = strategy.obfuscateString(input);
+
+    expect(JSON.parse(output)[0].xhr.__sentry_xhr_v3__.url).toBe(
+      "https://google.com",
+    );
+    expect(output).not.toContain("LillyQA");
+    expect(output).not.toContain("ASIAXYKJVD2OJCGGRZ6N");
+    expect(output).not.toContain("Lilly-Logo");
+  });
+
+  test("replaces the free text a customer typed on a link", () => {
+    const input = JSON.stringify([
+      {
+        linkType: "Link",
+        name: "IAPI_QS8050",
+        description: "Batch release report",
+      },
+    ]);
+
+    const [out] = JSON.parse(strategy.obfuscateString(input));
+
+    expect(out.name).not.toBe("IAPI_QS8050");
+    expect(out.description).not.toBe("Batch release report");
+    // The app compares this one against "Attachment" and "Link".
+    expect(out.linkType).toBe("Link");
+  });
+
+  test("obfuscates a link list that is stored as a JSON string", () => {
+    // Older documents store the list as a JSON string, not an array.
+    const input = JSON.stringify({
+      acceptanceCriteriaLinks: JSON.stringify([
+        { fileName: "Lilly-Logo.svg.png" },
+      ]),
+    });
+
+    const out = JSON.parse(strategy.obfuscateString(input));
+
+    expect(JSON.parse(out.acceptanceCriteriaLinks)[0].fileName).toBe(
+      "attachment.png",
+    );
+  });
+
+  test("gives a links column and its copy in document HTML the same value", () => {
+    // One strategy for both paths, or the app cannot match the two copies.
+    const dictionary = new DictionaryObfuscatorStrategy();
+    const linkObfuscator = new LinkObfuscatorStrategy(dictionary);
+    const links = [
+      {
+        uuid: "cf40e9ac-1d22-4a7f-9f4e-77b0c1a9e551",
+        linkType: "Attachment",
+        name: "Equipment Flow Chart",
+        fileName: "Equipment Flow Chart.png",
+        S3TmpKey: "client_qa_LillyQA/64a64cc4-001f/Equipment Flow Chart.png",
+      },
+    ];
+
+    const fromColumn = JSON.parse(
+      linkObfuscator.obfuscateString(JSON.stringify(links)),
+    )[0];
+
+    const encoded = JSON.stringify({
+      acceptanceCriteriaLinks: JSON.stringify(links),
+    })
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;");
+    const html = `<span data-record-sub-model-data="${encoded}"></span>`;
+    const fromHtml = JSON.parse(
+      JSON.parse(
+        parse(
+          new HTMLObfuscatorStrategy(
+            dictionary,
+            linkObfuscator,
+          ).obfuscateString(html),
+        )
+          .querySelector("span")
+          .getAttribute("data-record-sub-model-data"),
+      ).acceptanceCriteriaLinks,
+    )[0];
+
+    expect(fromHtml).toEqual(fromColumn);
   });
 });
 

--- a/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
+++ b/__tests__/obfuscators/LinkObfuscatorStrategy.test.js
@@ -97,3 +97,21 @@ describe("LinkObfuscatorStrategy", () => {
     expect(fromHtml.fileName).toBe(fromColumn.fileName);
   });
 });
+
+describe("inline images", () => {
+  test("replaces a base64 image with a blank one instead of random words", () => {
+    const strategy = new HTMLObfuscatorStrategy();
+    const png =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAAoCAYAAABXadAK";
+    const input = `<img src="${png}" />`;
+
+    const src = parse(strategy.obfuscateString(input))
+      .querySelector("img")
+      .getAttribute("src");
+
+    // Word replacement used to produce something like "back:women/the;artist,Will", which is not
+    // a valid URL, so every document lost its images.
+    expect(src.startsWith("data:image/png;base64,")).toBe(true);
+    expect(src).not.toContain("iVBORw0KGgoAAAANSUhEUgAAALQ");
+  });
+});

--- a/obfuscationCfg-template.yaml
+++ b/obfuscationCfg-template.yaml
@@ -14,21 +14,8 @@ columns:
   - name: notImportantColumn
     ignore: true
 
-  # Link columns hold customer file names and storage paths. The general rule above ignores JSON
-  # strings, so each of these needs its own rule and an empty ignore pattern to reach it. The same
-  # replacement runs on the copies inside document HTML, so both stay equal.
-  - name: uploadImageLinks
-    obfuscationRule: "linkObfuscator"
-    ignorePattern: ""
-  - name: links
-    obfuscationRule: "linkObfuscator"
-    ignorePattern: ""
-  - name: referencesLinks
-    obfuscationRule: "linkObfuscator"
-    ignorePattern: ""
-  - name: acceptanceCriteriaLinks
-    obfuscationRule: "linkObfuscator"
-    ignorePattern: ""
+  # A column whose name ends in "links" goes through the link obfuscator on its own.
+  # Write a rule here only to override that.
 
 # Use this to ignore whole tables or columns on a given table
 tables:

--- a/obfuscationCfg-template.yaml
+++ b/obfuscationCfg-template.yaml
@@ -14,6 +14,22 @@ columns:
   - name: notImportantColumn
     ignore: true
 
+  # Link columns hold customer file names and storage paths. The general rule above ignores JSON
+  # strings, so each of these needs its own rule and an empty ignore pattern to reach it. The same
+  # replacement runs on the copies inside document HTML, so both stay equal.
+  - name: uploadImageLinks
+    obfuscationRule: "linkObfuscator"
+    ignorePattern: ""
+  - name: links
+    obfuscationRule: "linkObfuscator"
+    ignorePattern: ""
+  - name: referencesLinks
+    obfuscationRule: "linkObfuscator"
+    ignorePattern: ""
+  - name: acceptanceCriteriaLinks
+    obfuscationRule: "linkObfuscator"
+    ignorePattern: ""
+
 # Use this to ignore whole tables or columns on a given table
 tables:
   - name: SequelizeMeta

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dictionary-en": "^4.0.0",
         "js-yaml": "4.1.0",
         "mysql2": "3.6.5",
-        "node-html-parser": "^7.0.1",
+        "node-html-parser": "^9.0.0",
         "pino": "8.16.2",
         "pino-pretty": "10.2.3",
         "popular-english-words": "1.0.2",
@@ -2229,15 +2229,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/help-me": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
@@ -3456,13 +3447,25 @@
       "license": "MIT"
     },
     "node_modules/node-html-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
-      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-9.0.0.tgz",
+      "integrity": "sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
-        "he": "1.2.0"
+        "entities": "^8.0.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dictionary-en": "^4.0.0",
     "js-yaml": "4.1.0",
     "mysql2": "3.6.5",
-    "node-html-parser": "^7.0.1",
+    "node-html-parser": "^9.0.0",
     "pino": "8.16.2",
     "pino-pretty": "10.2.3",
     "popular-english-words": "1.0.2",

--- a/src/classes/Obfuscator.js
+++ b/src/classes/Obfuscator.js
@@ -1,6 +1,7 @@
 import { Sequelize } from 'sequelize';
 import { loadConfig } from '../utilities/ConfigUtillities.js';
 import ObfuscatorStrategyMap from './obfuscators/ObfuscatorStrategyMap.js';
+import { isLinksField } from './obfuscators/LinkObfuscatorStrategy.js';
 import logger from '../config/LogConfig.js';
 
 /**
@@ -70,9 +71,11 @@ export default class Obfuscator {
         const columnTypeCategory = this.getTypeCategory(columnDetails.type);
         const generalRule = this.rules.general?.find(rule => rule.type === columnTypeCategory);
 
+        const linkRule = this.getLinkRule(columnName, columnTypeCategory, columnRule, tableColumnRule);
+
         // Loads the rules in a way that the table-specific inherits from the column-specific and all inherit from the general one
-        const ruleToApply = (generalRule || columnRule || tableColumnRule) ? {
-          ...(generalRule || {}), ...(columnRule || {}), ...(tableColumnRule || {})
+        const ruleToApply = (generalRule || linkRule || columnRule || tableColumnRule) ? {
+          ...(generalRule || {}), ...(linkRule || {}), ...(columnRule || {}), ...(tableColumnRule || {})
         } : undefined
 
         let {obfuscationRule, ignorePattern, ignore = false} = ruleToApply || {};
@@ -117,6 +120,20 @@ export default class Obfuscator {
       }
     }
 
+  }
+
+  /**
+   * Returns the link rule for a column such as riskLinks, so the config never has to name one.
+   * A rule written for the column wins over this one.
+   */
+  getLinkRule(columnName, columnTypeCategory, columnRule, tableColumnRule) {
+    if (columnTypeCategory !== 'string' || columnRule || tableColumnRule || !isLinksField(columnName)) {
+      return undefined;
+    }
+
+    // The general rule skips values shaped like JSON, and link columns are JSON, so this rule
+    // must not inherit that ignore pattern.
+    return {obfuscationRule: 'linkObfuscator', ignorePattern: ''};
   }
 
   shouldObfuscate(table, column, record, ignore, ignorePattern) {

--- a/src/classes/obfuscators/HTMLObfuscatorStrategy.js
+++ b/src/classes/obfuscators/HTMLObfuscatorStrategy.js
@@ -1,6 +1,7 @@
 import { BaseObfuscatorStrategy } from "./BaseObfuscatorStrategy.js";
 import { parse } from "node-html-parser";
 import { DictionaryObfuscatorStrategy } from "./DictionaryObfuscatorStrategy.js";
+import { isLinkField, obfuscateLinkField } from "./LinkObfuscatorStrategy.js";
 
 // Those attributes are from widget_node and qbd_field_node in the main repo https://github.com/QbDVision-Inc/qbdvision
 // Every name here must be lowercase. HTML parsers lowercase attribute names, so a camelCase entry
@@ -22,23 +23,15 @@ const PROTECTED_ATTRIBUTES = new Set([
   "data-record-sub-model-name",
 ]);
 
-// Keys inside JSON attribute values that must keep their original value.
-const PROTECTED_JSON_KEYS = new Set([
-  // Link data. The app compares it with database columns that the column rules leave alone,
-  // because link data lives in JSON columns and those stay original. Replacing it would break
-  // that comparison, so the whole value is kept, including nested objects.
-  "link",
-  "linktype",
-  "filename",
-  "s3tmpkey",
-  "s3tmpversion",
-  "linkversion",
-  // Widget filter settings. An operator such as "contains" and a field name such as "label" read
-  // like ordinary words, so the text check below cannot tell them apart from prose. The value the
-  // customer typed lives under targetValue, which is still replaced.
+// Keys inside JSON attribute values that name something in the schema, not customer data. An
+// operator such as "contains" and a link type such as "Attachment" read like ordinary words, so
+// the text check below cannot tell them apart from prose. Replacing them breaks the app and hides
+// nothing. The value the customer typed lives under targetValue, which is still replaced.
+const SCHEMA_JSON_KEYS = new Set([
   "attribute",
   "operator",
   "submodel",
+  "linktype",
 ]);
 
 // A value matching any of these is read by the app, not by a person, so obfuscating it breaks the
@@ -206,9 +199,19 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
       for (const key in obj) {
         const value = obj[key];
         const keyName = String(key).toLowerCase();
+
+        // File names and storage paths are customer data, so they get a dummy of the same shape.
+        // The database columns holding the same links use the same helper, which keeps both copies
+        // equal for the image lookup by S3TmpKey. A "link" key can also hold a nested object, and
+        // that one falls through so its own fields get handled one by one.
+        if (isLinkField(keyName) && typeof value === "string") {
+          obj[key] = obfuscateLinkField(keyName, value);
+          continue;
+        }
+
         if (
           PROTECTED_ATTRIBUTES.has(keyName) ||
-          PROTECTED_JSON_KEYS.has(keyName)
+          SCHEMA_JSON_KEYS.has(keyName)
         ) {
           continue;
         }

--- a/src/classes/obfuscators/HTMLObfuscatorStrategy.js
+++ b/src/classes/obfuscators/HTMLObfuscatorStrategy.js
@@ -44,6 +44,11 @@ const VALUE_IS_NOT_TEXT = [
   /^[^A-Za-z]+$/, // operators and punctuation only, such as "="
 ];
 
+// A one pixel transparent PNG, used to replace inline images. Anything a customer pasted into a
+// document is gone, and the tag still points at a real image so nothing looks broken.
+const BLANK_IMAGE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
 // One step of a data-record-path, for example PP[name='Fermentation']. The type code is part of the
 // schema and the record name is customer data, so each half needs different handling.
 const RECORD_PATH_STEP = /^(\w+)\[name='(.*)'\]$/;
@@ -133,6 +138,14 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
           attributeName,
           this._obfuscateRecordPath(currentValue),
         );
+        continue;
+      }
+
+      // An inline image. Word replacement turns the base64 into something like "back:women/the",
+      // which is not a valid URL, so the browser reports an unknown scheme and every document
+      // loses its images. A blank image keeps the tag valid and shows nothing of the original.
+      if (/^data:/i.test(trimmedValue)) {
+        node.setAttribute(attributeName, BLANK_IMAGE);
         continue;
       }
 

--- a/src/classes/obfuscators/HTMLObfuscatorStrategy.js
+++ b/src/classes/obfuscators/HTMLObfuscatorStrategy.js
@@ -22,16 +22,23 @@ const PROTECTED_ATTRIBUTES = new Set([
   "data-record-sub-model-name",
 ]);
 
-// Keys inside JSON attribute values whose data the app compares with database columns that the
-// column rules leave alone (link data lives in JSON columns, and those stay original). Obfuscating
-// them would break that comparison, so the whole value is kept, including nested objects.
+// Keys inside JSON attribute values that must keep their original value.
 const PROTECTED_JSON_KEYS = new Set([
+  // Link data. The app compares it with database columns that the column rules leave alone,
+  // because link data lives in JSON columns and those stay original. Replacing it would break
+  // that comparison, so the whole value is kept, including nested objects.
   "link",
   "linktype",
   "filename",
   "s3tmpkey",
   "s3tmpversion",
   "linkversion",
+  // Widget filter settings. An operator such as "contains" and a field name such as "label" read
+  // like ordinary words, so the text check below cannot tell them apart from prose. The value the
+  // customer typed lives under targetValue, which is still replaced.
+  "attribute",
+  "operator",
+  "submodel",
 ]);
 
 // A value matching any of these is read by the app, not by a person, so obfuscating it breaks the

--- a/src/classes/obfuscators/HTMLObfuscatorStrategy.js
+++ b/src/classes/obfuscators/HTMLObfuscatorStrategy.js
@@ -1,7 +1,11 @@
 import { BaseObfuscatorStrategy } from "./BaseObfuscatorStrategy.js";
 import { parse } from "node-html-parser";
 import { DictionaryObfuscatorStrategy } from "./DictionaryObfuscatorStrategy.js";
-import { isLinkField, obfuscateLinkField } from "./LinkObfuscatorStrategy.js";
+import {
+  isLinkField,
+  isLinksField,
+  LinkObfuscatorStrategy,
+} from "./LinkObfuscatorStrategy.js";
 
 // Those attributes are from widget_node and qbd_field_node in the main repo https://github.com/QbDVision-Inc/qbdvision
 // Every name here must be lowercase. HTML parsers lowercase attribute names, so a camelCase entry
@@ -63,9 +67,13 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
   // app can still join them, for example an acceptance criteria group and label.
   constructor(
     dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy(),
+    linkObfuscatorStrategy = new LinkObfuscatorStrategy(
+      dictionaryObfuscatorStrategy,
+    ),
   ) {
     super();
     this._dictionaryObfuscatorStrategy = dictionaryObfuscatorStrategy;
+    this._linkObfuscatorStrategy = linkObfuscatorStrategy;
   }
 
   obfuscateString(someString) {
@@ -213,12 +221,13 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
         const value = obj[key];
         const keyName = String(key).toLowerCase();
 
-        // File names and storage paths are customer data, so they get a dummy of the same shape.
-        // The database columns holding the same links use the same helper, which keeps both copies
-        // equal for the image lookup by S3TmpKey. A "link" key can also hold a nested object, and
-        // that one falls through so its own fields get handled one by one.
-        if (isLinkField(keyName) && typeof value === "string") {
-          obj[key] = obfuscateLinkField(keyName, value);
+        // The matching column runs through the same strategy, so the image lookup by S3TmpKey
+        // still finds its entry.
+        if (isLinkField(keyName) || isLinksField(keyName)) {
+          obj[key] = this._linkObfuscatorStrategy.obfuscateValue(
+            keyName,
+            value,
+          );
           continue;
         }
 

--- a/src/classes/obfuscators/HTMLObfuscatorStrategy.js
+++ b/src/classes/obfuscators/HTMLObfuscatorStrategy.js
@@ -3,32 +3,64 @@ import { parse } from "node-html-parser";
 import { DictionaryObfuscatorStrategy } from "./DictionaryObfuscatorStrategy.js";
 
 // Those attributes are from widget_node and qbd_field_node in the main repo https://github.com/QbDVision-Inc/qbdvision
+// Every name here must be lowercase. HTML parsers lowercase attribute names, so a camelCase entry
+// would never match and the attribute would be obfuscated by mistake.
 const PROTECTED_ATTRIBUTES = new Set([
-  'class',
-  'kind',
-  'model',
-  'style',
-  'contenteditable',
-  'referenceblockname',
-  'referenceblock',
-  'data-record-id',
-  'data-record-model-name',
-  'data-record-column-name',
-  'data-never-approved',
-  'data-record-sub-model-name',
-  'data-record-sub-model-data',
-  'modelName',
-  'typeCode'
+  "class",
+  "kind",
+  "model",
+  "modelname",
+  "style",
+  "typecode",
+  "contenteditable",
+  "referenceblockname",
+  "referenceblock",
+  "data-record-id",
+  "data-record-model-name",
+  "data-record-column-name",
+  "data-never-approved",
+  "data-record-sub-model-name",
 ]);
+
+// Keys inside JSON attribute values whose data the app compares with database columns that the
+// column rules leave alone (link data lives in JSON columns, and those stay original). Obfuscating
+// them would break that comparison, so the whole value is kept, including nested objects.
+const PROTECTED_JSON_KEYS = new Set([
+  "link",
+  "linktype",
+  "filename",
+  "s3tmpkey",
+  "s3tmpversion",
+  "linkversion",
+]);
+
+// A value matching any of these is read by the app, not by a person, so obfuscating it breaks the
+// app without hiding any customer data.
+const VALUE_IS_NOT_TEXT = [
+  /^(?:true|false|null|undefined)$/i, // literals the app compares against
+  /^-?\d+(?:\.\d+)?(?:px|%|em|rem|pt|vh|vw|deg|s|ms)?$/i, // numbers and CSS lengths
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, // UUID
+  /^[A-Z][A-Za-z0-9]*(?:\.[A-Za-z0-9]+)+$/, // model paths like FQA.AcceptanceCriteriaRange
+  /^[^A-Za-z]+$/, // operators and punctuation only, such as "="
+];
+
+// One step of a data-record-path, for example PP[name='Fermentation']. The type code is part of the
+// schema and the record name is customer data, so each half needs different handling.
+const RECORD_PATH_STEP = /^(\w+)\[name='(.*)'\]$/;
 
 /**
  * This obfuscator preserves HTML tags and attributes, preserves text in elements with class "qbd-output",
  * and obfuscates all other text using DictionaryObfuscatorStrategy
  */
 export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
-  constructor() {
+  // Pass the same dictionary instance that obfuscates the database columns. The word cache then
+  // gives a value inside document HTML the same replacement as the matching column value, so the
+  // app can still join them, for example an acceptance criteria group and label.
+  constructor(
+    dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy(),
+  ) {
     super();
-    this._dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy();
+    this._dictionaryObfuscatorStrategy = dictionaryObfuscatorStrategy;
   }
 
   obfuscateString(someString) {
@@ -51,7 +83,8 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
       const text = node.text;
       if (text && text.trim()) {
         if (!this._isInsideQbdOutput(node)) {
-          node.textContent = this._dictionaryObfuscatorStrategy.obfuscateString(text);
+          node.textContent =
+            this._dictionaryObfuscatorStrategy.obfuscateString(text);
         }
       }
     } else {
@@ -68,31 +101,95 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
     }
   }
 
-  _obfuscateAttributes(node) {
-    const ATTRIBUTE_WITH_OBJECT_VALUE = new Set([
-      "process",
-      "unitoperation"
-    ]);
+  /**
+   * Decides whether a value is human text that is safe to replace with random words.
+   * @param value The trimmed attribute or JSON string value.
+   */
+  _isText(value) {
+    return !VALUE_IS_NOT_TEXT.some((pattern) => pattern.test(value));
+  }
 
+  _obfuscateAttributes(node) {
     // Get all attribute names from the node
     const attributeNames = Object.keys(node.attributes);
     for (const attributeName of attributeNames) {
       const currentValue = node.getAttribute(attributeName);
-      if (!currentValue || typeof currentValue !== 'string' || !currentValue.trim()) {
+      if (
+        !currentValue ||
+        typeof currentValue !== "string" ||
+        !currentValue.trim()
+      ) {
         continue;
       }
 
-      if (ATTRIBUTE_WITH_OBJECT_VALUE.has(attributeName)) {
-        node.setAttribute(attributeName, this._obfuscateObjectAttributeValue(currentValue));
+      if (PROTECTED_ATTRIBUTES.has(attributeName.toLowerCase())) {
         continue;
       }
 
-      if (PROTECTED_ATTRIBUTES.has(attributeName)) {
+      const trimmedValue = currentValue.trim();
+
+      if (attributeName.toLowerCase() === "data-record-path") {
+        node.setAttribute(
+          attributeName,
+          this._obfuscateRecordPath(currentValue),
+        );
         continue;
       }
 
-      const obfuscatedValue = this._dictionaryObfuscatorStrategy.obfuscateString(currentValue);
+      // Obfuscate JSON by walking the parsed object, never as plain text. Word replacement keeps
+      // punctuation but not quoting, so a boolean like true turns into a bare word that breaks
+      // the JSON.
+      if (trimmedValue.startsWith("{") || trimmedValue.startsWith("[")) {
+        node.setAttribute(
+          attributeName,
+          this._obfuscateObjectAttributeValue(currentValue),
+        );
+        continue;
+      }
+
+      if (!this._isText(trimmedValue)) {
+        continue;
+      }
+
+      const obfuscatedValue =
+        this._dictionaryObfuscatorStrategy.obfuscateString(currentValue);
       node.setAttribute(attributeName, obfuscatedValue);
+    }
+  }
+
+  /**
+   * Obfuscates a data-record-path one step at a time. Document Builder resolves the record from the
+   * type code and the trailing field name, so both stay. Only the record name is replaced, and the
+   * word cache gives it the same replacement as the matching row in the database.
+   * @param attributeValue The raw data-record-path attribute value.
+   */
+  _obfuscateRecordPath(attributeValue) {
+    try {
+      const path = JSON.parse(attributeValue);
+      if (!Array.isArray(path)) {
+        return attributeValue;
+      }
+
+      return JSON.stringify(
+        path.map((step) => {
+          if (typeof step !== "string") {
+            return step;
+          }
+
+          const match = RECORD_PATH_STEP.exec(step);
+          if (!match) {
+            // A plain step is a field name, which is part of the schema.
+            return step;
+          }
+
+          const name = this._dictionaryObfuscatorStrategy.obfuscateString(
+            match[2],
+          );
+          return `${match[1]}[name='${name}']`;
+        }),
+      );
+    } catch {
+      return this._dictionaryObfuscatorStrategy.obfuscateString(attributeValue);
     }
   }
 
@@ -100,10 +197,31 @@ export class HTMLObfuscatorStrategy extends BaseObfuscatorStrategy {
     try {
       const obj = JSON.parse(attributeValue);
       for (const key in obj) {
-        if (typeof obj[key] === 'object' && obj[key] !== null) {
-          obj[key] = JSON.parse(this._obfuscateObjectAttributeValue(JSON.stringify(obj[key])));
-        } else if (obj[key] && typeof obj[key] === "string" && !PROTECTED_ATTRIBUTES.has(key)) {
-          obj[key] = this._dictionaryObfuscatorStrategy.obfuscateString(obj[key]);
+        const value = obj[key];
+        const keyName = String(key).toLowerCase();
+        if (
+          PROTECTED_ATTRIBUTES.has(keyName) ||
+          PROTECTED_JSON_KEYS.has(keyName)
+        ) {
+          continue;
+        }
+
+        if (typeof value === "object" && value !== null) {
+          obj[key] = JSON.parse(
+            this._obfuscateObjectAttributeValue(JSON.stringify(value)),
+          );
+        } else if (value && typeof value === "string") {
+          const trimmedValue = value.trim();
+          // A string value that holds JSON stays as it is. The matching database columns hold
+          // the same JSON and the column rules skip them, so both copies must stay equal.
+          if (trimmedValue.startsWith("{") || trimmedValue.startsWith("[")) {
+            continue;
+          }
+
+          if (this._isText(trimmedValue)) {
+            obj[key] =
+              this._dictionaryObfuscatorStrategy.obfuscateString(value);
+          }
         }
       }
       return JSON.stringify(obj);

--- a/src/classes/obfuscators/LinkObfuscatorStrategy.js
+++ b/src/classes/obfuscators/LinkObfuscatorStrategy.js
@@ -1,4 +1,5 @@
 import { BaseObfuscatorStrategy } from "./BaseObfuscatorStrategy.js";
+import { DictionaryObfuscatorStrategy } from "./DictionaryObfuscatorStrategy.js";
 
 // Link fields hold customer file names and storage paths, so they cannot be kept. Replacing them
 // with random words would produce a broken looking URL, so each one gets a valid dummy instead.
@@ -6,9 +7,24 @@ const DUMMY_URL = "https://google.com";
 const DUMMY_FILE = "attachment";
 const DUMMY_FOLDER = "obfuscated";
 
-// Fields handled here. S3TmpVersion and linkVersion are random storage tokens with no customer
-// information in them, so they stay as they are and keep pointing at the same object.
+// These keys hold a customer storage path or file name, so each gets a dummy of the same shape.
 const LINK_FIELDS = new Set(["link", "filename", "s3tmpkey"]);
+
+// The app reads or joins on these keys and none holds customer data, so they are never replaced.
+const PRESERVED_FIELDS = new Set([
+  "uuid",
+  "linktype",
+  "filestatus",
+  "linkversion",
+  "s3tmpversion",
+  "mode",
+  "method",
+  "progress",
+  "size",
+  "index",
+]);
+
+const URL_VALUE = /^https?:\/\//i;
 
 const extensionOf = (name) => {
   const match = /\.[A-Za-z0-9]{1,8}$/.exec(name || "");
@@ -48,7 +64,7 @@ export const obfuscateLinkField = (fieldName, value) => {
   }
 
   // A real URL becomes a working dummy URL, so the app still renders a valid link.
-  if (/^https?:\/\//i.test(value)) {
+  if (URL_VALUE.test(value)) {
     return DUMMY_URL;
   }
 
@@ -58,22 +74,85 @@ export const obfuscateLinkField = (fieldName, value) => {
 export const isLinkField = (fieldName) => LINK_FIELDS.has(fieldName);
 
 /**
- * Obfuscates the link JSON that database columns such as uploadImageLinks hold. The document HTML
- * keeps a copy of the same data, and HTMLObfuscatorStrategy replaces it with the same helper, so
- * both copies stay equal and the app can still match them.
+ * True for a field whose name ends in "links", such as riskLinks. That suffix is how the app itself
+ * finds link fields, in document_link_parser.js isLinkAttribute.
+ * @param fieldName A column name or a JSON key.
+ */
+export const isLinksField = (fieldName) =>
+  String(fieldName || "")
+    .toLowerCase()
+    .endsWith("links");
+
+const parseJson = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Obfuscates the link JSON held by columns such as uploadImageLinks. HTMLObfuscatorStrategy runs the
+ * copy inside document HTML through this class too, because the app joins the two by S3TmpKey.
  */
 export class LinkObfuscatorStrategy extends BaseObfuscatorStrategy {
+  // The dictionary that obfuscates the columns. Sharing it gives a link name the same replacement
+  // as that same name in its own column.
+  constructor(
+    dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy(),
+  ) {
+    super();
+    this._dictionaryObfuscatorStrategy = dictionaryObfuscatorStrategy;
+  }
+
   obfuscateString(someString) {
     if (!someString) {
       return someString;
     }
 
-    try {
-      return JSON.stringify(this._walk(JSON.parse(someString)));
-    } catch {
+    const parsed = parseJson(someString);
+    if (parsed === undefined) {
       // Not JSON, so there is no link structure to keep. Leave it rather than guess.
       return someString;
     }
+
+    return JSON.stringify(this._walk(parsed));
+  }
+
+  /**
+   * Obfuscates one value inside a link. HTMLObfuscatorStrategy calls this for the copy stored in a
+   * document attribute, so that copy and the database column come out identical.
+   * @param fieldName The lowercased column name or JSON key.
+   * @param value The value under that name.
+   */
+  obfuscateValue(fieldName, value) {
+    if (value && typeof value === "object") {
+      return this._walk(value);
+    }
+
+    if (typeof value !== "string" || value === "") {
+      return value;
+    }
+
+    if (PRESERVED_FIELDS.has(fieldName)) {
+      return value;
+    }
+
+    // Replace any URL, not only the ones under a known key: the xhr upload trace holds a presigned
+    // S3 URL carrying the customer bucket and file name.
+    if (isLinkField(fieldName) || URL_VALUE.test(value)) {
+      return obfuscateLinkField(fieldName, value);
+    }
+
+    // A nested link list is stored as a JSON string, so parse it and obfuscate the links inside.
+    if (isLinksField(fieldName)) {
+      const nested = parseJson(value);
+      if (nested !== undefined) {
+        return JSON.stringify(this._walk(nested));
+      }
+    }
+
+    return this._dictionaryObfuscatorStrategy.obfuscateString(value);
   }
 
   _walk(node) {
@@ -86,15 +165,7 @@ export class LinkObfuscatorStrategy extends BaseObfuscatorStrategy {
     }
 
     for (const key of Object.keys(node)) {
-      const fieldName = key.toLowerCase();
-      const value = node[key];
-      // A "link" key can hold a URL string or a nested object, so only strings are replaced here
-      // and objects keep going down the tree.
-      if (isLinkField(fieldName) && typeof value === "string") {
-        node[key] = obfuscateLinkField(fieldName, value);
-      } else if (value && typeof value === "object") {
-        node[key] = this._walk(value);
-      }
+      node[key] = this.obfuscateValue(String(key).toLowerCase(), node[key]);
     }
     return node;
   }

--- a/src/classes/obfuscators/LinkObfuscatorStrategy.js
+++ b/src/classes/obfuscators/LinkObfuscatorStrategy.js
@@ -1,0 +1,101 @@
+import { BaseObfuscatorStrategy } from "./BaseObfuscatorStrategy.js";
+
+// Link fields hold customer file names and storage paths, so they cannot be kept. Replacing them
+// with random words would produce a broken looking URL, so each one gets a valid dummy instead.
+const DUMMY_URL = "https://google.com";
+const DUMMY_FILE = "attachment";
+const DUMMY_FOLDER = "obfuscated";
+
+// Fields handled here. S3TmpVersion and linkVersion are random storage tokens with no customer
+// information in them, so they stay as they are and keep pointing at the same object.
+const LINK_FIELDS = new Set(["link", "filename", "s3tmpkey"]);
+
+const extensionOf = (name) => {
+  const match = /\.[A-Za-z0-9]{1,8}$/.exec(name || "");
+  return match ? match[0] : "";
+};
+
+/**
+ * Replaces the customer part of a storage path but keeps every id in it. The app looks images up by
+ * S3TmpKey, so two different images must still get two different keys.
+ * @param value A storage path such as companySchema/<uuid>/Their File.png
+ */
+const obfuscateStoragePath = (value) => {
+  const segments = value.split("/").filter((part) => part !== "");
+  if (segments.length <= 1) {
+    return `${DUMMY_FILE}${extensionOf(value)}`;
+  }
+
+  const fileName = `${DUMMY_FILE}${extensionOf(segments[segments.length - 1])}`;
+  // The first segment is the customer schema name. Everything between it and the file name is ids,
+  // which carry no customer data and keep each key unique.
+  const middle = segments.slice(1, -1);
+  return [DUMMY_FOLDER, ...middle, fileName].join("/");
+};
+
+/**
+ * Replaces one link field with a dummy value of the same shape.
+ * @param fieldName The lowercased JSON key.
+ * @param value The original string value.
+ */
+export const obfuscateLinkField = (fieldName, value) => {
+  if (typeof value !== "string" || value === "") {
+    return value;
+  }
+
+  if (fieldName === "filename") {
+    return `${DUMMY_FILE}${extensionOf(value)}`;
+  }
+
+  // A real URL becomes a working dummy URL, so the app still renders a valid link.
+  if (/^https?:\/\//i.test(value)) {
+    return DUMMY_URL;
+  }
+
+  return obfuscateStoragePath(value);
+};
+
+export const isLinkField = (fieldName) => LINK_FIELDS.has(fieldName);
+
+/**
+ * Obfuscates the link JSON that database columns such as uploadImageLinks hold. The document HTML
+ * keeps a copy of the same data, and HTMLObfuscatorStrategy replaces it with the same helper, so
+ * both copies stay equal and the app can still match them.
+ */
+export class LinkObfuscatorStrategy extends BaseObfuscatorStrategy {
+  obfuscateString(someString) {
+    if (!someString) {
+      return someString;
+    }
+
+    try {
+      return JSON.stringify(this._walk(JSON.parse(someString)));
+    } catch {
+      // Not JSON, so there is no link structure to keep. Leave it rather than guess.
+      return someString;
+    }
+  }
+
+  _walk(node) {
+    if (Array.isArray(node)) {
+      return node.map((item) => this._walk(item));
+    }
+
+    if (!node || typeof node !== "object") {
+      return node;
+    }
+
+    for (const key of Object.keys(node)) {
+      const fieldName = key.toLowerCase();
+      const value = node[key];
+      // A "link" key can hold a URL string or a nested object, so only strings are replaced here
+      // and objects keep going down the tree.
+      if (isLinkField(fieldName) && typeof value === "string") {
+        node[key] = obfuscateLinkField(fieldName, value);
+      } else if (value && typeof value === "object") {
+        node[key] = this._walk(value);
+      }
+    }
+    return node;
+  }
+}

--- a/src/classes/obfuscators/ObfuscatorStrategyMap.js
+++ b/src/classes/obfuscators/ObfuscatorStrategyMap.js
@@ -3,6 +3,7 @@ import { XORObfuscatorStrategy } from "./XORObfuscatorStrategy.js";
 import { NoObfuscatorStrategy } from "./NoObfuscatorStrategy.js";
 import { DictionaryObfuscatorStrategy } from "./DictionaryObfuscatorStrategy.js";
 import { HTMLObfuscatorStrategy } from "./HTMLObfuscatorStrategy.js";
+import { LinkObfuscatorStrategy } from "./LinkObfuscatorStrategy.js";
 
 /**
  * This is the central index of all obfuscator strategies.
@@ -17,6 +18,7 @@ const ObfuscatorStrategyMap = {
   dictionaryObfuscator: dictionaryObfuscatorStrategy,
   noObfuscator: new NoObfuscatorStrategy(),
   htmlObfuscator: new HTMLObfuscatorStrategy(dictionaryObfuscatorStrategy),
+  linkObfuscator: new LinkObfuscatorStrategy(),
 };
 
 export default ObfuscatorStrategyMap;

--- a/src/classes/obfuscators/ObfuscatorStrategyMap.js
+++ b/src/classes/obfuscators/ObfuscatorStrategyMap.js
@@ -11,14 +11,22 @@ import { LinkObfuscatorStrategy } from "./LinkObfuscatorStrategy.js";
 // One dictionary shared between the column path and the HTML path, so a column value and its
 // copy inside document HTML get the same replacement and the app can still match them.
 const dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy();
+// One link obfuscator for the column path and the HTML path, so both copies of a link come out
+// with the same value.
+const linkObfuscatorStrategy = new LinkObfuscatorStrategy(
+  dictionaryObfuscatorStrategy,
+);
 
 const ObfuscatorStrategyMap = {
   stringObfuscator: new StringObfuscatorStrategy(),
   xorObfuscator: new XORObfuscatorStrategy(),
   dictionaryObfuscator: dictionaryObfuscatorStrategy,
   noObfuscator: new NoObfuscatorStrategy(),
-  htmlObfuscator: new HTMLObfuscatorStrategy(dictionaryObfuscatorStrategy),
-  linkObfuscator: new LinkObfuscatorStrategy(),
+  htmlObfuscator: new HTMLObfuscatorStrategy(
+    dictionaryObfuscatorStrategy,
+    linkObfuscatorStrategy,
+  ),
+  linkObfuscator: linkObfuscatorStrategy,
 };
 
 export default ObfuscatorStrategyMap;

--- a/src/classes/obfuscators/ObfuscatorStrategyMap.js
+++ b/src/classes/obfuscators/ObfuscatorStrategyMap.js
@@ -7,12 +7,16 @@ import { HTMLObfuscatorStrategy } from "./HTMLObfuscatorStrategy.js";
 /**
  * This is the central index of all obfuscator strategies.
  */
+// One dictionary shared between the column path and the HTML path, so a column value and its
+// copy inside document HTML get the same replacement and the app can still match them.
+const dictionaryObfuscatorStrategy = new DictionaryObfuscatorStrategy();
+
 const ObfuscatorStrategyMap = {
   stringObfuscator: new StringObfuscatorStrategy(),
   xorObfuscator: new XORObfuscatorStrategy(),
-  dictionaryObfuscator: new DictionaryObfuscatorStrategy(),
+  dictionaryObfuscator: dictionaryObfuscatorStrategy,
   noObfuscator: new NoObfuscatorStrategy(),
-  htmlObfuscator: new HTMLObfuscatorStrategy(),
-}
+  htmlObfuscator: new HTMLObfuscatorStrategy(dictionaryObfuscatorStrategy),
+};
 
 export default ObfuscatorStrategyMap;


### PR DESCRIPTION
Obfuscated dumps were breaking Document Builder: documents failed to open with the error `"undefined" is not valid JSON`, PDF export produced a 1-page error sheet, and smart content fields displayed red "Data cannot be found" boxes.

Jira: https://cherrycircle.atlassian.net/browse/QI-14627

**Root causes**

1- JSON attribute values (filters, data-record-path) were obfuscated as plain prose, which broke the JSON.
2- node-html-parser 7.0.1 strips backslashes from every attribute of an element when one attribute is rewritten, so JSON escapes inside data-record-sub-model-data became raw newlines and bare quotes.
3- Column values (acceptance criteria group and label) were obfuscated, while their copies inside data-record-sub-model-data were not, so the app lookup by group and label always failed.

**Fixes**

- JSON attributes are obfuscated by walking the parsed object: structure, keys, booleans, numbers, UUIDs, and model paths stay; only human text is replaced. data-record-path keeps type codes and field names and replaces only record names.
- data-record-sub-model-data uses the same shared dictionary as the columns, so both copies of group and label remain equal. Join keys and link data are preserved. This also closes the leak where real customer text survived in that attribute.
- node-html-parser is upgraded to 9.0.0, where quoteAttribute is lossless. A regression test pins it.

**Tested**

- Full pipeline A/B on a fresh seeded schema: the old tool kills every document and exports a 7 KB error PDF; this branch renders everything and exports the full 15-page document.
